### PR TITLE
Handle additional rep params

### DIFF
--- a/matric/0.knit-notebooks.Rmd
+++ b/matric/0.knit-notebooks.Rmd
@@ -56,6 +56,8 @@ params:
           - Metadata_cell_line
           - Metadata_gene_name
           - Metadata_reference_or_other
+        any_different_cols_rep: NULL
+        all_different_cols_rep: NULL
         all_same_cols_rep_ref: NULL
         any_different_cols_non_rep: 
           - Metadata_gene_name

--- a/matric/2.calculate_index.Rmd
+++ b/matric/2.calculate_index.Rmd
@@ -19,6 +19,8 @@ params:
         - Metadata_cell_line
         - Metadata_gene_name
         - Metadata_reference_or_other
+      any_different_cols_rep: NULL
+      all_different_cols_rep: NULL
       all_same_cols_rep_ref: NULL
       any_different_cols_non_rep: 
         - Metadata_gene_name
@@ -151,6 +153,8 @@ collated_sim <-
       sim_df = sim_df,
       reference = reference_df,
       all_same_cols_rep = all_same_cols_rep,
+      all_different_cols_rep = all_different_cols_rep,
+      all_different_cols_rep = all_different_cols_rep,
       all_same_cols_rep_ref = all_same_cols_rep_ref,
       all_same_cols_ref = all_same_cols_ref,
       any_different_cols_non_rep = any_different_cols_non_rep,

--- a/matric/2.calculate_index.Rmd
+++ b/matric/2.calculate_index.Rmd
@@ -154,7 +154,7 @@ collated_sim <-
       reference = reference_df,
       all_same_cols_rep = all_same_cols_rep,
       all_different_cols_rep = all_different_cols_rep,
-      all_different_cols_rep = all_different_cols_rep,
+      any_different_cols_rep = any_different_cols_rep,
       all_same_cols_rep_ref = all_same_cols_rep_ref,
       all_same_cols_ref = all_same_cols_ref,
       any_different_cols_non_rep = any_different_cols_non_rep,

--- a/renv.lock
+++ b/renv.lock
@@ -228,7 +228,7 @@
     },
     "blob": {
       "Package": "blob",
-      "Version": "1.2.3",
+      "Version": "1.2.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -236,7 +236,7 @@
         "rlang",
         "vctrs"
       ],
-      "Hash": "10d231579bc9c06ab1c320618808d4ff"
+      "Hash": "40415719b5a479b87949f3aa0aee737c"
     },
     "broom": {
       "Package": "broom",
@@ -415,10 +415,10 @@
     },
     "commonmark": {
       "Package": "commonmark",
-      "Version": "1.8.1",
+      "Version": "1.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "b6e3e947d1d7ebf3d2bdcea1bde63fe7"
+      "Hash": "d691c61bff84bd63c383874d2d0c3307"
     },
     "conflicted": {
       "Package": "conflicted",
@@ -954,14 +954,18 @@
     },
     "gtable": {
       "Package": "gtable",
-      "Version": "0.3.1",
+      "Version": "0.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
-        "grid"
+        "cli",
+        "glue",
+        "grid",
+        "lifecycle",
+        "rlang"
       ],
-      "Hash": "36b4265fb818f6a342bed217549cd896"
+      "Hash": "651b5a984e5a43dca1e7a6e671423233"
     },
     "hardhat": {
       "Package": "hardhat",
@@ -1043,7 +1047,7 @@
     },
     "htmlwidgets": {
       "Package": "htmlwidgets",
-      "Version": "1.6.1",
+      "Version": "1.6.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1054,7 +1058,7 @@
         "rmarkdown",
         "yaml"
       ],
-      "Hash": "b677ee5954471eaa974c0d099a343a1a"
+      "Hash": "a865aa85bcb2697f47505bfd70422471"
     },
     "httpuv": {
       "Package": "httpuv",
@@ -1310,11 +1314,11 @@
       "Version": "0.1.0",
       "Source": "GitHub",
       "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteRepo": "matric",
       "RemoteUsername": "shntnu",
-      "RemoteRef": "null_df",
-      "RemoteSha": "a2adb70e437cd1f07020ada415292590220d4ff1",
+      "RemoteRepo": "matric",
+      "RemoteRef": "fix_signal_stat_n",
+      "RemoteSha": "48ac4b98dcbe93b39b00f857cf00ed1311431d06",
+      "RemoteHost": "api.github.com",
       "Requirements": [
         "R",
         "arrow",
@@ -1336,7 +1340,7 @@
         "tidyr",
         "yardstick"
       ],
-      "Hash": "ab6353150e1beacd9443747b47539fcd"
+      "Hash": "afe541bad3c8d742f5ef2544d5707651"
     },
     "memoise": {
       "Package": "memoise",
@@ -1784,13 +1788,13 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "0.17.0",
+      "Version": "0.17.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
-      "Hash": "ce3065fc1a0b64a859f55ac3998d6927"
+      "Hash": "aaf3c7f769695266a2113db67a25148b"
     },
     "reprex": {
       "Package": "reprex",
@@ -1840,14 +1844,14 @@
     },
     "rlang": {
       "Package": "rlang",
-      "Version": "1.0.6",
+      "Version": "1.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "4ed1f8336c8d52c3e750adcdc57228a7"
+      "Hash": "dc079ccd156cde8647360f473c1fa718"
     },
     "rmarkdown": {
       "Package": "rmarkdown",
@@ -2051,7 +2055,7 @@
     },
     "survival": {
       "Package": "survival",
-      "Version": "3.5-3",
+      "Version": "3.5-5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2063,7 +2067,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "aea2b8787db7088ba50ba389848569ee"
+      "Hash": "d683341b1fa2e8d817efde27d6e6d35b"
     },
     "sys": {
       "Package": "sys",
@@ -2261,7 +2265,7 @@
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.5.2",
+      "Version": "0.6.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2271,7 +2275,7 @@
         "lifecycle",
         "rlang"
       ],
-      "Hash": "e4ffa94ceed5f124d429a5a5f0f5b378"
+      "Hash": "7e877404388794361277be95d8445de8"
     },
     "viridisLite": {
       "Package": "viridisLite",

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,7 @@
 local({
 
   # the requested version of renv
-  version <- "0.17.0"
+  version <- "0.17.2"
 
   # the project directory
   project <- getwd()

--- a/renv/settings.json
+++ b/renv/settings.json
@@ -1,0 +1,17 @@
+{
+  "bioconductor.version": null,
+  "external.libraries": [],
+  "ignored.packages": [],
+  "package.dependency.fields": [
+    "Imports",
+    "Depends",
+    "LinkingTo"
+  ],
+  "r.version": [],
+  "snapshot.type": "implicit",
+  "use.cache": true,
+  "vcs.ignore.cellar": true,
+  "vcs.ignore.library": true,
+  "vcs.ignore.local": true,
+  "vcs.manage.ignores": true
+}


### PR DESCRIPTION
This is a breaking change because two new params need to be defined

```
any_different_cols_rep
all_different_cols_rep
```

The notebooks are setup a bit sloppily, so these MUST be defined in the param, even if left empty (or set to NULL)

#16 actually fixes the param files
